### PR TITLE
Show comment only if it was created by current user or user is admin

### DIFF
--- a/ckanext/ytp/comments/templates/package/comment_list.html
+++ b/ckanext/ytp/comments/templates/package/comment_list.html
@@ -30,6 +30,7 @@
 
     <div class="comment-wrapper">
     {% for comment in thread.comments %}
+        {% if (comment.user_id == c.userobj.id) or c.userobj.sysadmin%}
         {{ comment.id }}
         <div class="comment">
             {% if comment.state != 'deleted' %}
@@ -71,6 +72,7 @@
             {% if comment.comments | length != 0 %}
                 {{ comment_thread(comment) }}
             {% endif %}
+        {% endif %}
     {% endfor %}
     </div>
 


### PR DESCRIPTION
### what does the PR do
- Makes comment visible only to their authors
- Makes all comments visible to admin users

### Changes made
- If condition to check if the user is admin or author before displaying comment